### PR TITLE
Feat: look for git projects inside base folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-dashboard",
-    "version": "2.0.0",
+    "version": "2.2.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -30,6 +30,15 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@types/klaw": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@types/klaw/-/klaw-3.0.1.tgz",
+            "integrity": "sha512-acnF3n9mYOr1aFJKFyvfNX0am9EtPUsYPq22QUCGdJE+MVt6UyAN1jwo+PmOPqXD4K7ZS9MtxDEp/un0lxFccA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/mocha": {
             "version": "7.0.2",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
@@ -41,6 +50,15 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.32.tgz",
             "integrity": "sha512-44/reuCrwiQEsXud3I5X3sqI5jIXAmHB5xoiyKUw965olNHF3IWKjBLKK3F9LOSUZmK+oDt8jmyO637iX+hMgA==",
             "dev": true
+        },
+        "@types/through2": {
+            "version": "2.0.36",
+            "resolved": "https://registry.npmjs.org/@types/through2/-/through2-2.0.36.tgz",
+            "integrity": "sha512-vuifQksQHJXhV9McpVsXKuhnf3lsoX70PnhcqIAbs9dqLH2NgrGz0DzZPDY3+Yh6eaRqcE1gnCQ6QhBn1/PT5A==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
         },
         "@webassemblyjs/ast": {
             "version": "1.9.0",
@@ -2165,6 +2183,18 @@
             "requires": {
                 "graceful-fs": "^4.1.11",
                 "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "fs-write-stream-atomic": {
@@ -3042,6 +3072,16 @@
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
                 }
             }
         },
@@ -3677,6 +3717,15 @@
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
+        "klaw": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.9"
+            }
+        },
         "last-run": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/last-run/-/last-run-1.1.1.tgz",
@@ -4071,6 +4120,16 @@
                     "requires": {
                         "end-of-stream": "^1.1.0",
                         "once": "^1.3.1"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
                     }
                 }
             }
@@ -5052,6 +5111,18 @@
                 "remove-bom-buffer": "^3.0.0",
                 "safe-buffer": "^5.1.0",
                 "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "remove-trailing-separator": {
@@ -5868,13 +5939,12 @@
             }
         },
         "through2": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+            "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
             "dev": true,
             "requires": {
-                "readable-stream": "~2.3.6",
-                "xtend": "~4.0.1"
+                "readable-stream": "2 || 3"
             }
         },
         "through2-filter": {
@@ -5885,6 +5955,18 @@
             "requires": {
                 "through2": "~2.0.0",
                 "xtend": "~4.0.0"
+            },
+            "dependencies": {
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "ticky": {
@@ -5973,6 +6055,18 @@
             "dev": true,
             "requires": {
                 "through2": "^2.0.3"
+            },
+            "dependencies": {
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "tough-cookie": {
@@ -6412,6 +6506,18 @@
                 "value-or-function": "^3.0.0",
                 "vinyl": "^2.0.0",
                 "vinyl-sourcemap": "^1.1.0"
+            },
+            "dependencies": {
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
+                    }
+                }
             }
         },
         "vinyl-sourcemap": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,10 @@
             {
                 "command": "dashboard.editProjects",
                 "title": "Project Dashboard: Edit Projects"
+            },
+            {
+                "command": "dashboard.refreshProjects",
+                "title": "Project Dashboard: Refresh Projects"
             }
         ],
         "keybindings": [
@@ -119,6 +123,16 @@
                 "dashboard.customProjectPathColor": {
                     "type": "string",
                     "default": null
+                },
+                "dashboard.projectsBaseDirectories": {
+                    "description": "Array of directories to look for projects (git initialized only).",
+                    "type": "array",
+                    "default": []
+                },
+                "dashboard.projectsDepthLimit": {
+                    "description": "The number of times to recursively look for projects before stopping.",
+                    "type": "number",
+                    "default": 2
                 }
             }
         }
@@ -131,15 +145,19 @@
         "lint": "tslint -p ./"
     },
     "devDependencies": {
+        "@types/klaw": "^3.0.1",
         "@types/mocha": "^7.0.2",
         "@types/node": "^12.12.32",
+        "@types/through2": "^2.0.36",
         "dragula": "^3.7.2",
         "fitty": "^2.3.0",
         "gulp": "^4.0.2",
         "gulp-clean-css": "^4.3.0",
         "gulp-sass": "^4.0.2",
+        "klaw": "^3.0.0",
         "lodash": "^4.17.15",
         "node-sass": "^4.13.1",
+        "through2": "^3.0.1",
         "ts-loader": "^6.2.2",
         "tslint": "^5.20.1",
         "typescript": "^3.8.3",


### PR DESCRIPTION
Hello!
I love this extension and decide to add a feature to get all git projects inside a base folder.

**Features:**

- Base folders are defined inside the user's settings, with an optional depth limit (default is 2).
```json
{
    "dashboard.projectsBaseDirectories": ["C:\\workspace"],
    "dashboard.projectsDepthLimit": 2
}
```

- Each base directory forms a group and the git directories found inside are added to it.
- If the directory exists in **any** other group, it is skipped.
- The project`s name is the directory basename and the color is randomized.

**Fixes:**
- Changed the `isFolderGitRepo` function based on this [answer](https://stackoverflow.com/a/56581777), because it was not working for me.