### PR TITLE
Add an option control '+ New Group' item visibility in the dashboard

### DIFF
--- a/media/webviewDnDScripts.js
+++ b/media/webviewDnDScripts.js
@@ -25,11 +25,13 @@ function initDnD() {
     function onReordered() {
         // Build reordering object
         let groupElements = [...document.querySelectorAll(`${groupsContainerSelector} > [data-group-id]`)];
-        // If a project was dropped on the Create New Group element...
-        let tempGroupElement = document.querySelector('#tempGroup');
-        if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
-            // ... Handle it as a new group
-            groupElements.push(tempGroupElement);
+        // If showAddGroupButtonTile setting is true & a project was dropped on the Create New Group element...
+        if (infos.config.showAddGroupButtonTile) {
+            let tempGroupElement = document.querySelector('#tempGroup');
+            if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
+                // ... Handle it as a new group
+                groupElements.push(tempGroupElement);
+            }
         }
 
         let groupOrders = [];

--- a/package.json
+++ b/package.json
@@ -107,9 +107,14 @@
                         "never"
                     ]
                 },
+                "dashboard.showAddGroupButtonTile": {
+                    "type": "boolean",
+                    "markdownDescription": "If set to ```false```, the '+ New Group' tile is hidden. Groups can be added by using the Command Palette (default ```F1```) with 'dashboard: Add Group' action. The dashboard needs to be refreshed for the changes to take effect.",
+                    "default": true
+                },
                 "dashboard.showAddProjectButtonTile": {
                     "type": "boolean",
-                    "markdownDescription": "If set to ```false```, the dedicated '+' tile is hidden inside groups. Projects can be added by using the actions when hovering the group name.",
+                    "markdownDescription": "If set to ```false```, the dedicated '+' tile is hidden inside groups. Projects can be added by using the actions when hovering the group name. The dashboard needs to be refreshed for the changes to take effect.",
                     "default": true
                 },
                 "dashboard.customProjectCardBackground": {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -97,7 +97,7 @@ export function getDashboardContent(context: vscode.ExtensionContext, webview: v
 function getGroupSection(group: Group, totalGroupCount: number, infos: DashboardInfos) {
     // Apply changes to HTML here also to getTempGroupSection
 
-    var showAddButton = infos.config.showAddProjectButtonTile;
+    var showAddProjectButton = infos.config.showAddProjectButtonTile;
 
     return `
 <div class="group ${group.collapsed ? 'collapsed' : ''} ${group.projects.length === 0 ? 'no-projects' : ''}" data-group-id="${group.id}">
@@ -115,7 +115,7 @@ function getGroupSection(group: Group, totalGroupCount: number, infos: Dashboard
     <div class="group-list">
         <div class="drop-signal"></div>
         ${group.projects.map(p => getProjectDiv(p, infos)).join('\n')}
-        ${showAddButton ? getAddProjectDiv(group.id) : ""}
+        ${showAddProjectButton ? getAddProjectDiv(group.id) : ""}
     </div>       
 </div>`;
 }

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -36,6 +36,7 @@ export function getDashboardContent(context: vscode.ExtensionContext, webview: v
     var dndScriptsPath = getMediaResource(context, webview, 'webviewDnDScripts.js');
 
     var customCss = infos.config.get('customCss') || "";
+    var showAddGroupButton = infos.config.showAddGroupButtonTile;
 
     return `
 <!DOCTYPE html>
@@ -65,7 +66,7 @@ export function getDashboardContent(context: vscode.ExtensionContext, webview: v
         }
             </div>
 
-            ${getTempGroupSection(groups.length)}
+            ${showAddGroupButton ? getTempGroupSection(groups.length) : ''}
         </div>
 
         ${getProjectContextMenu()}

--- a/src/webview/webviewDnDScripts.js
+++ b/src/webview/webviewDnDScripts.js
@@ -25,11 +25,13 @@ function initDnD() {
     function onReordered() {
         // Build reordering object
         let groupElements = [...document.querySelectorAll(`${groupsContainerSelector} > [data-group-id]`)];
-        // If a project was dropped on the Create New Group element...
-        let tempGroupElement = document.querySelector('#tempGroup');
-        if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
-            // ... Handle it as a new group
-            groupElements.push(tempGroupElement);
+        // If showAddGroupButtonTile setting is true & a project was dropped on the Create New Group element...
+        if (infos.config.showAddGroupButtonTile) {
+            let tempGroupElement = document.querySelector('#tempGroup');
+            if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
+                // ... Handle it as a new group
+                groupElements.push(tempGroupElement);
+            }
         }
 
         let groupOrders = [];


### PR DESCRIPTION
Kept ```tempGroupElement``` integrity, adding the ```showAddGroupButtonTile``` setting to control the display of the entire div & made the drag & drop responsive to the setting.

Fixes #72