### PR TITLE
Add an option controlling '+ New Group' item visibility in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,252 +6,253 @@ All notable changes to the "Project Dashboard" extension will be documented in t
 
 ### Added
 
--   Clicking a project with the middle mouse button opens it in a new tab.
+- Clicking a project with the middle mouse button opens it in a new tab.
+- Added an option controlling '+ New Group' visibility in the dashboard
 
 ### Fixed
 
--   Fixed grammar. :)
+- Fixed grammar. :)
 
 ## [2.3.2] 2021-07-16
 
 ### Changed
 
--   Set `extensionKind` to `["ui", "workspace"]`, following [https://github.com/Kruemelkatze/vscode-dashboard/issues/65](https://github.com/Kruemelkatze/vscode-dashboard/issues/65).
+- Set `extensionKind` to `["ui", "workspace"]`, following [https://github.com/Kruemelkatze/vscode-dashboard/issues/65](https://github.com/Kruemelkatze/vscode-dashboard/issues/65).
 
 ## [2.3.1] 2020-11-23
 
 ### Changed
 
--   Upon clicking the sidebar icon, the sidebar view switches to the explorer instead of closing itself. This fixes an unrecoverable state when the dashboard view is placed under another sidebar view container.
+- Upon clicking the sidebar icon, the sidebar view switches to the explorer instead of closing itself. This fixes an unrecoverable state when the dashboard view is placed under another sidebar view container.
 
 ## [2.3.0] 2020-11-23
 
 ### Added
 
--   Sidebar icon for opening the project dashboard.
+- Sidebar icon for opening the project dashboard.
 
 ### Changed
 
--   The dashboard now has a dedicated icon.
+- The dashboard now has a dedicated icon.
 
 ## [2.2.2] 2020-07-03
 
 ### Fixed
 
--   Editing dashboard.projectData in settings does not wrongly format null value any more.
+- Editing dashboard.projectData in settings does not wrongly format null value any more.
 
 ## [2.2.1] 2020-05-13
 
 ### Fixed
 
--   Opening remote SSH folder projects.
--   Opening remote projects in new window.
+- Opening remote SSH folder projects.
+- Opening remote projects in new window.
 
 ## [2.2.0] 2020-05-12
 
 ### Changed
 
--   Allow any characters in SSH remote string.
--   Renamed _File or Multi-Root Project_ to _Workspace or File Project_.
+- Allow any characters in SSH remote string.
+- Renamed _File or Multi-Root Project_ to _Workspace or File Project_.
 
 ### Fixed
 
--   Null safe group sanitizing.
+- Null safe group sanitizing.
 
 ## [2.1.2] 2020-04-29
 
 ### Changed
 
--   Allow loading external images in webview.
+- Allow loading external images in webview.
 
 ## [2.1.1] 2020-04-29
 
 ### Fixed
 
--   Fixed editing projects manually.
--   Strip HTML tags from project name when adding it to the workspace.
+- Fixed editing projects manually.
+- Strip HTML tags from project name when adding it to the workspace.
 
 ## [2.1.0] 2020-04-21
 
 ### Added
 
--   "Add Project to Workspace" context menu action for folders and multi-root workspaces.
+- "Add Project to Workspace" context menu action for folders and multi-root workspaces.
 
 ### Changed
 
--   When adding a file or folder project, the file system picker is set to the current workspace per default.
+- When adding a file or folder project, the file system picker is set to the current workspace per default.
 
 ## [2.0.2] 2020-04-13
 
 ### Fixed
 
--   Fixed Storage Consistency.
+- Fixed Storage Consistency.
 
 ## [2.0.1] 2020-04-11
 
 ### Fixed
 
--   Context Menu is now correctly placed when the Dashboard is scrolled.
+- Context Menu is now correctly placed when the Dashboard is scrolled.
 
 ## [2.0.0] 2020-04-11
 
 ### Changed
 
--   Renamed extension to **Project Dashboard**.
--   Project and Group Management
-    -   'Project Groups' are now referred to as only 'Groups'.
-    -   Empty groups are no longer removed.
-    -   Groups can now be added by a dedicated button.
-    -   When adding a project using any + button in the group, user is now longer prompted to select a group.
-    -   Editing project no longer includes editing the color. For this, a dedicated action was added.
-    -   Reordered group actions to be consistent with project actions.
--   Colors
-    -   Random colors are now selected from a large array of colours, not only from the limited set of default colors.
--   All animations have now an equal duration. Delay for actions has been lowered to 250ms.
+- Renamed extension to **Project Dashboard**.
+- Project and Group Management
+  - 'Project Groups' are now referred to as only 'Groups'.
+  - Empty groups are no longer removed.
+  - Groups can now be added by a dedicated button.
+  - When adding a project using any + button in the group, user is now longer prompted to select a group.
+  - Editing project no longer includes editing the color. For this, a dedicated action was added.
+  - Reordered group actions to be consistent with project actions.
+- Colors
+  - Random colors are now selected from a large array of colours, not only from the limited set of default colors.
+- All animations have now an equal duration. Delay for actions has been lowered to 250ms.
 
 ### Added
 
--   Groups can be collapsed
--   Context menus for projects and groups that include all actions.
--   Colors
-    -   Project color can now be changed directly from the dashboard without going through the whole project editing phase.
-    -   Selection for recently used colors.
-    -   Custom colors are now named using [Name that Color](http://chir.ag/projects/name-that-color/#6195ED).
-    -   Custom Project Card background now allows for any CSS background value.
--   Setting for project tile width.
+- Groups can be collapsed
+- Context menus for projects and groups that include all actions.
+- Colors
+  - Project color can now be changed directly from the dashboard without going through the whole project editing phase.
+  - Selection for recently used colors.
+  - Custom colors are now named using [Name that Color](http://chir.ag/projects/name-that-color/#6195ED).
+  - Custom Project Card background now allows for any CSS background value.
+- Setting for project tile width.
 
 ### Fixed
 
--   Changing the data source (globalState or user settings) now directly migrates the data and updates the dashboard.
+- Changing the data source (globalState or user settings) now directly migrates the data and updates the dashboard.
 
 ### Internal
 
--   Refactored Webview
--   Refactored Services
+- Refactored Webview
+- Refactored Services
 
 ## [1.5.5] 2019-11-09
 
 ### Fixed
 
--   Fixed all css transitions firing on opening dashboard, triggered by a bug in the Chromium version used by VSCode 1.40.0.
+- Fixed all css transitions firing on opening dashboard, triggered by a bug in the Chromium version used by VSCode 1.40.0.
 
 ## [1.5.4] 2019-11-08
 
 ### Fixed
 
--   Fixed error on opening file/folder dialog on VSCode 1.40.0
+- Fixed error on opening file/folder dialog on VSCode 1.40.0
 
 ## [1.5.3] 2019-11-06
 
 ### Fixed
 
--   Cmd + click for opening in new window on Mac.
+- Cmd + click for opening in new window on Mac.
 
 ### Internal
 
--   Extension package is now significantly smaller.
+- Extension package is now significantly smaller.
 
 ## [1.5.2] 2019-10-25
 
 ### Fixed
 
--   Dashboard settings are now correctly fetched without restarting.
+- Dashboard settings are now correctly fetched without restarting.
 
 ## [1.5.1] 2019-10-24
 
 ### Changed
 
--   Group name is now mandatory, as the group name is always displayed. So enforcing a name makes sense.
+- Group name is now mandatory, as the group name is always displayed. So enforcing a name makes sense.
 
 ### Fixed
 
--   Escape/Unfocus on entering group name now cancels the add/edit action instead of having an unnamed group.
+- Escape/Unfocus on entering group name now cancels the add/edit action instead of having an unnamed group.
 
 ## [1.5] 2019-10-22
 
 ### Added
 
--   Support for [Remote Development Projects](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack).
--   Added config for startup behaviour (always, empty workspace, never).
--   Editing and rearranging projects groups directly on the dashboard.
--   Option for storing projects in the User Settings (to be synced via [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync)).
--   Setting for removing the big '+' button, but added a smaller one next to the group name.
+- Support for [Remote Development Projects](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack).
+- Added config for startup behaviour (always, empty workspace, never).
+- Editing and rearranging projects groups directly on the dashboard.
+- Option for storing projects in the User Settings (to be synced via [Settings Sync](https://marketplace.visualstudio.com/items?itemName=Shan.code-settings-sync)).
+- Setting for removing the big '+' button, but added a smaller one next to the group name.
 
 ### Changed
 
--   Default option for color is now 'Random', as most people use colors. :-)
--   Editing a project via UI now also prompts for editing its path.
--   Reduced number of message from the extension.
--   Temporary file for editing is now safely placed in the [Global storage path](https://code.visualstudio.com/updates/v1_31#_global-storage-path). This also removed the need for the custom temp file location setting.
--   Indicated Dashboard as "ui"-type extension, so that it works without installing if a remote workspace (SSH, WSL, Container) is opened in VSCode.
+- Default option for color is now 'Random', as most people use colors. :-)
+- Editing a project via UI now also prompts for editing its path.
+- Reduced number of message from the extension.
+- Temporary file for editing is now safely placed in the [Global storage path](https://code.visualstudio.com/updates/v1_31#_global-storage-path). This also removed the need for the custom temp file location setting.
+- Indicated Dashboard as "ui"-type extension, so that it works without installing if a remote workspace (SSH, WSL, Container) is opened in VSCode.
 
 ### Fixed
 
--   Fixed some exceptions thrown when user cancelled any input (by pressing esc or unfocusing the window).
--   Fixed a bug that made the dashboard not open automatically because of a hidden file of the **_Code Runner_** extension.
+- Fixed some exceptions thrown when user cancelled any input (by pressing esc or unfocusing the window).
+- Fixed a bug that made the dashboard not open automatically because of a hidden file of the **_Code Runner_** extension.
 
 ## [1.4.1] 2019-07-11
 
 ### Fixed
 
--   Fixed issue that nothing shows on the dashboard, if a user updates from 1.2.0 to 1.4.0 with only an empty, unnamed group.
+- Fixed issue that nothing shows on the dashboard, if a user updates from 1.2.0 to 1.4.0 with only an empty, unnamed group.
 
 ## [1.4] 2019-07-07
 
 ### Added
 
--   Support for gradient borders.
+- Support for gradient borders.
 
 ### Changed
 
--   Removed color input validation in order to support any color definition.
+- Removed color input validation in order to support any color definition.
 
 ### Fixed
 
--   Editing projects now correctly sets color.
+- Editing projects now correctly sets color.
 
 ## [1.3] 2019-06-27
 
 ### Added
 
--   Editing functionality directly on Dashboard
-    -   Reordering by drag & drop
-    -   Edit button
-    -   Remove button
--   Setting for editing project temp file location
--   Prefill project name from selected path
--   `displayProjectPath` setting
+- Editing functionality directly on Dashboard
+  - Reordering by drag & drop
+  - Edit button
+  - Remove button
+- Setting for editing project temp file location
+- Prefill project name from selected path
+- `displayProjectPath` setting
 
 ### Changed
 
--   When editing the dashboard manually, empty unnamed groups are removed after saving.
--   Removed "Blank Page" icon of dashboard.
+- When editing the dashboard manually, empty unnamed groups are removed after saving.
+- Removed "Blank Page" icon of dashboard.
 
 ## [1.2] 2018-12-06
 
 ### Added
 
--   Groups
--   Color Customization Options in settings
--   Detect if project is a Git repository. If so, display an icon.
+- Groups
+- Color Customization Options in settings
+- Detect if project is a Git repository. If so, display an icon.
 
 ### Changed
 
--   When adding a project, a group has to be selected.
+- When adding a project, a group has to be selected.
 
 ## [1.1] 2018-09-25
 
 ### Added
 
--   Support for Multi-Root Workspaces
+- Support for Multi-Root Workspaces
 
 ### Changed
 
--   When adding a project, a project type (folder or file/multi-workspace) has to be selected at first.
+- When adding a project, a project type (folder or file/multi-workspace) has to be selected at first.
 
 ### Fixed
 
--   Editing Projects now works under Linux (moved to another temp path)
+- Editing Projects now works under Linux (moved to another temp path)
 
 ## [1.0.0] 2018-09-23
 
@@ -259,11 +260,11 @@ All notable changes to the "Project Dashboard" extension will be documented in t
 
 ### Added
 
--   Ctrl + F1 as default keybinding for Dashboard: Open command
+- Ctrl + F1 as default keybinding for Dashboard: Open command
 
 ### Fixed
 
--   Add project button now works when no projects are in the dashboard
+- Add project button now works when no projects are in the dashboard
 
 # Pre-releases
 
@@ -271,31 +272,31 @@ All notable changes to the "Project Dashboard" extension will be documented in t
 
 ### Added
 
--   Project name scales to fit card
--   Long project paths are truncated (left)
--   Ctrl + Click on project opens the project in a new window
--   If project is already opened, an info message is shown
+- Project name scales to fit card
+- Long project paths are truncated (left)
+- Ctrl + Click on project opens the project in a new window
+- If project is already opened, an info message is shown
 
 ### Changes
 
--   When editing the projects file, the file is closed after save
+- When editing the projects file, the file is closed after save
 
 ## [0.1.3] 2018-09-09
 
 ### Added
 
--   Add project button
+- Add project button
 
 ### Fixed
 
--   Clicking on newly added projects now works
+- Clicking on newly added projects now works
 
 ## [0.1.2] 2018-09-06
 
 ### Added
 
--   Extension information and icon
+- Extension information and icon
 
 ## [0.1.1] 2018-09-06
 
--   Initial pre-release
+- Initial pre-release

--- a/media/webviewDnDScripts.js
+++ b/media/webviewDnDScripts.js
@@ -25,11 +25,13 @@ function initDnD() {
     function onReordered() {
         // Build reordering object
         let groupElements = [...document.querySelectorAll(`${groupsContainerSelector} > [data-group-id]`)];
-        // If a project was dropped on the Create New Group element...
-        let tempGroupElement = document.querySelector('#tempGroup');
-        if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
-            // ... Handle it as a new group
-            groupElements.push(tempGroupElement);
+        // If showAddGroupButtonTile setting is true & a project was dropped on the Create New Group element...
+        if (infos.config.showAddGroupButtonTile) {
+            let tempGroupElement = document.querySelector('#tempGroup');
+            if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
+                // ... Handle it as a new group
+                groupElements.push(tempGroupElement);
+            }
         }
 
         let groupOrders = [];

--- a/package.json
+++ b/package.json
@@ -107,9 +107,14 @@
                         "never"
                     ]
                 },
+                "dashboard.showAddGroupButtonTile": {
+                    "type": "boolean",
+                    "markdownDescription": "If set to ```false```, the '+ New Group' tile is hidden. Groups can be added by using the Command Palette (default ```F1```) with 'dashboard: Add Group' action. The dashboard needs to be refreshed for the changes to take effect.",
+                    "default": true
+                },
                 "dashboard.showAddProjectButtonTile": {
                     "type": "boolean",
-                    "markdownDescription": "If set to ```false```, the dedicated '+' tile is hidden inside groups. Projects can be added by using the actions when hovering the group name.",
+                    "markdownDescription": "If set to ```false```, the dedicated '+' tile is hidden inside groups. Projects can be added by using the actions when hovering the group name. The dashboard needs to be refreshed for the changes to take effect.",
                     "default": true
                 },
                 "dashboard.customProjectCardBackground": {

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -90,7 +90,7 @@ export function getDashboardContent(
         }
             </div>
 
-            ${getTempGroupSection(groups.length)}
+            ${infos.config.showAddGroupButtonTile ? getTempGroupSection(groups.length) : ''}
         </div>
 
         ${getProjectContextMenu()}

--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -1,12 +1,18 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 
-import { Project, Group, getRemoteType, ProjectRemoteType, DashboardInfos } from "../models";
+import {
+  Project,
+  Group,
+  getRemoteType,
+  ProjectRemoteType,
+  DashboardInfos,
+} from '../models';
 import { FITTY_OPTIONS, REMOTE_REGEX } from '../constants';
 import * as Icons from './webviewIcons';
 
 export function getSidebarContent() {
-    return `
+  return `
 <!DOCTYPE html>
     <html lang="en">
     <head>
@@ -27,24 +33,39 @@ export function getSidebarContent() {
 `;
 }
 
-export function getDashboardContent(context: vscode.ExtensionContext, webview: vscode.Webview, groups: Group[], infos: DashboardInfos): string {
-    var stylesPath = getMediaResource(context, webview, 'styles.css');
-    var fittyPath = getMediaResource(context, webview, 'fitty.min.js');
-    var dragulaPath = getMediaResource(context, webview, 'dragula.min.js');
+export function getDashboardContent(
+  context: vscode.ExtensionContext,
+  webview: vscode.Webview,
+  groups: Group[],
+  infos: DashboardInfos
+): string {
+  var stylesPath = getMediaResource(context, webview, 'styles.css');
+  var fittyPath = getMediaResource(context, webview, 'fitty.min.js');
+  var dragulaPath = getMediaResource(context, webview, 'dragula.min.js');
 
-    var projectScriptsPath = getMediaResource(context, webview, 'webviewProjectScripts.js');
-    var dndScriptsPath = getMediaResource(context, webview, 'webviewDnDScripts.js');
+  var projectScriptsPath = getMediaResource(
+    context,
+    webview,
+    'webviewProjectScripts.js'
+  );
+  var dndScriptsPath = getMediaResource(
+    context,
+    webview,
+    'webviewDnDScripts.js'
+  );
 
-    var customCss = infos.config.get('customCss') || "";
+  var customCss = infos.config.get('customCss') || '';
 
-    return `
+  return `
 <!DOCTYPE html>
     <html lang="en">
     <head>
         <meta charset="UTF-8">
         <meta
             http-equiv="Content-Security-Policy"
-            content="default-src 'none'; img-src * data:; script-src ${webview.cspSource} 'unsafe-inline'; style-src ${webview.cspSource} 'unsafe-inline';"
+            content="default-src 'none'; img-src * data:; script-src ${
+              webview.cspSource
+            } 'unsafe-inline'; style-src ${webview.cspSource} 'unsafe-inline';"
         />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" type="text/css" href="${stylesPath}">
@@ -57,11 +78,15 @@ export function getDashboardContent(context: vscode.ExtensionContext, webview: v
     </head>
     <body class="preload ${!groups.length ? 'dashboard-empty' : ''}">
         <div class="">
-            <div class="groups-wrapper ${!infos.config.displayProjectPath ? 'hide-project-path' : ''}">
-        ${groups.length ?
-            groups.map(group => getGroupSection(group, groups.length, infos)).join('\n')
-            :
-            getNoProjectsDiv()
+            <div class="groups-wrapper ${
+              !infos.config.displayProjectPath ? 'hide-project-path' : ''
+            }">
+        ${
+          groups.length
+            ? groups
+                .map((group) => getGroupSection(group, groups.length, infos))
+                .join('\n')
+            : getNoProjectsDiv()
         }
             </div>
 
@@ -94,34 +119,44 @@ export function getDashboardContent(context: vscode.ExtensionContext, webview: v
 </html>`;
 }
 
-function getGroupSection(group: Group, totalGroupCount: number, infos: DashboardInfos) {
-    // Apply changes to HTML here also to getTempGroupSection
+function getGroupSection(
+  group: Group,
+  totalGroupCount: number,
+  infos: DashboardInfos
+) {
+  // Apply changes to HTML here also to getTempGroupSection
 
-    var showAddButton = infos.config.showAddProjectButtonTile;
+  var showAddProjectButton = infos.config.showAddProjectButtonTile;
 
-    return `
-<div class="group ${group.collapsed ? 'collapsed' : ''} ${group.projects.length === 0 ? 'no-projects' : ''}" data-group-id="${group.id}">
+  return `
+<div class="group ${group.collapsed ? 'collapsed' : ''} ${
+    group.projects.length === 0 ? 'no-projects' : ''
+  }" data-group-id="${group.id}">
     <div class="group-title">
         <span class="group-title-text" data-action="collapse" data-drag-group>
-            <span class="collapse-icon" title="Open/Collapse Group">${Icons.collapse}</span>
-            ${group.groupName || "Unnamed Group"}
+            <span class="collapse-icon" title="Open/Collapse Group">${
+              Icons.collapse
+            }</span>
+            ${group.groupName || 'Unnamed Group'}
         </span>
         <div class="group-actions right">
             <span data-action="add" title="Add Project">${Icons.add}</span>
             <span data-action="edit" title="Edit Group">${Icons.edit}</span>
-            <span data-action="remove" title="Remove Group">${Icons.remove}</span>
+            <span data-action="remove" title="Remove Group">${
+              Icons.remove
+            }</span>
         </div>
     </div>
     <div class="group-list">
         <div class="drop-signal"></div>
-        ${group.projects.map(p => getProjectDiv(p, infos)).join('\n')}
-        ${showAddButton ? getAddProjectDiv(group.id) : ""}
+        ${group.projects.map((p) => getProjectDiv(p, infos)).join('\n')}
+        ${showAddProjectButton ? getAddProjectDiv(group.id) : ''}
     </div>       
 </div>`;
 }
 
 function getTempGroupSection(totalGroupCount: number) {
-    return `
+  return `
 <div class="group" id="tempGroup">
     <div class="group-title" data-action="add-group">
         <span>${Icons.add} New Group</span>
@@ -135,22 +170,30 @@ function getTempGroupSection(totalGroupCount: number) {
 }
 
 function getProjectDiv(project: Project, infos: DashboardInfos) {
-    var borderStyle = `background: ${project.color};`
-    var remoteType = getRemoteType(project);
-    var trimmedPath = (project.path || '').replace(REMOTE_REGEX, '');
+  var borderStyle = `background: ${project.color};`;
+  var remoteType = getRemoteType(project);
+  var trimmedPath = (project.path || '').replace(REMOTE_REGEX, '');
 
-    var isRemote = remoteType !== ProjectRemoteType.None;
-    var remoteExError = isRemote && !infos.relevantExtensionsInstalls.remoteSSH;
+  var isRemote = remoteType !== ProjectRemoteType.None;
+  var remoteExError = isRemote && !infos.relevantExtensionsInstalls.remoteSSH;
 
-    return `
+  return `
 <div class="project-container">
-    <div class="project" data-id="${project.id}" ${isRemote ? 'data-is-remote' : ''}>
+    <div class="project" data-id="${project.id}" ${
+    isRemote ? 'data-is-remote' : ''
+  }>
         <div class="project-border" style="${borderStyle}"></div>
         <div class="project-actions-wrapper">
             <div class="project-actions">
-                <span data-action="color" title="Edit Color">${Icons.palette}</span>
-                <span data-action="edit" title="Edit Project">${Icons.edit}</span>
-                <span data-action="remove" title="Remove Project">${Icons.remove}</span>
+                <span data-action="color" title="Edit Color">${
+                  Icons.palette
+                }</span>
+                <span data-action="edit" title="Edit Project">${
+                  Icons.edit
+                }</span>
+                <span data-action="remove" title="Remove Project">${
+                  Icons.remove
+                }</span>
             </div>
         </div>
         <div class="fitty-container">
@@ -159,38 +202,52 @@ function getProjectDiv(project: Project, infos: DashboardInfos) {
             </h2>
         </div>
         <p class="project-path-info">
-            ${isRemote ? `<span class="remote-icon ${remoteExError ? 'error-icon' : ''}" title="${remoteExError ? 'Remote Development extension is not installed' : 'Remote Project'}">${Icons.remote}</span>` : ''}
-            ${project.isGitRepo ? `<span class="git-icon" title="Git Repository">${Icons.gitSvg}</span>` : ''}
+            ${
+              isRemote
+                ? `<span class="remote-icon ${
+                    remoteExError ? 'error-icon' : ''
+                  }" title="${
+                    remoteExError
+                      ? 'Remote Development extension is not installed'
+                      : 'Remote Project'
+                  }">${Icons.remote}</span>`
+                : ''
+            }
+            ${
+              project.isGitRepo
+                ? `<span class="git-icon" title="Git Repository">${Icons.gitSvg}</span>`
+                : ''
+            }
             <span class="project-path" title="${trimmedPath}">${trimmedPath}</span>
         </p>
     </div>
-</div>`
+</div>`;
 }
 
 function getNoProjectsDiv() {
-    return `
+  return `
 <div class="project-container">
     <div class="project no-projects" data-action="add-project">
         No projects have been added yet.
         <br/>
         Click here to add one.
     </div>
-</div>`
+</div>`;
 }
 
 function getAddProjectDiv(groupId: string) {
-    return `
+  return `
 <span class="project-container slim last" data-nodrag>
     <div class="project add-project" data-action="add-project" data-group-id="${groupId}">
         <h2 class="add-project-header">
             +
         </h2>
     </div>
-</span>`
+</span>`;
 }
 
 function getProjectContextMenu() {
-    return `
+  return `
 <div id="projectContextMenu" class="custom-context-menu">
     <div class="custom-context-menu-item" data-action="open">
         Open Project
@@ -218,7 +275,7 @@ function getProjectContextMenu() {
 }
 
 function getGroupContextMenu() {
-    return `
+  return `
 <div id="groupContextMenu" class="custom-context-menu">   
     <div class="custom-context-menu-item" data-action="add">
         Add Project
@@ -234,23 +291,50 @@ function getGroupContextMenu() {
 }
 
 function getCustomStyle(config: vscode.WorkspaceConfiguration) {
-    var { customProjectCardBackground, customProjectNameColor, customProjectPathColor, projectTileWidth } = config;
+  var {
+    customProjectCardBackground,
+    customProjectNameColor,
+    customProjectPathColor,
+    projectTileWidth,
+  } = config;
 
-    // Nested Template Strings, hooray! \o/
-    return `
+  // Nested Template Strings, hooray! \o/
+  return `
 <style>
     :root {
-        ${customProjectCardBackground && customProjectCardBackground.trim() ? `--dashboard-project-card-bg: ${customProjectCardBackground};` : ''}
-        ${customProjectNameColor && customProjectNameColor.trim() ? `--dashboard-foreground: ${customProjectNameColor};` : ''}
-        ${customProjectPathColor && customProjectPathColor.trim() ? `--dashboard-path: ${customProjectPathColor};` : ''}
-        ${projectTileWidth && !isNaN(+projectTileWidth) ? `--column-width: ${projectTileWidth}px;` : ''}
+        ${
+          customProjectCardBackground && customProjectCardBackground.trim()
+            ? `--dashboard-project-card-bg: ${customProjectCardBackground};`
+            : ''
+        }
+        ${
+          customProjectNameColor && customProjectNameColor.trim()
+            ? `--dashboard-foreground: ${customProjectNameColor};`
+            : ''
+        }
+        ${
+          customProjectPathColor && customProjectPathColor.trim()
+            ? `--dashboard-path: ${customProjectPathColor};`
+            : ''
+        }
+        ${
+          projectTileWidth && !isNaN(+projectTileWidth)
+            ? `--column-width: ${projectTileWidth}px;`
+            : ''
+        }
     }
 </style>`;
 }
 
-function getMediaResource(context: vscode.ExtensionContext, webview: vscode.Webview, name: string) {
-    let resource = vscode.Uri.file(path.join(context.extensionPath, 'media', name));
-    resource = webview.asWebviewUri(resource);
+function getMediaResource(
+  context: vscode.ExtensionContext,
+  webview: vscode.Webview,
+  name: string
+) {
+  let resource = vscode.Uri.file(
+    path.join(context.extensionPath, 'media', name)
+  );
+  resource = webview.asWebviewUri(resource);
 
-    return resource;
+  return resource;
 }

--- a/src/webview/webviewDnDScripts.js
+++ b/src/webview/webviewDnDScripts.js
@@ -25,11 +25,13 @@ function initDnD() {
     function onReordered() {
         // Build reordering object
         let groupElements = [...document.querySelectorAll(`${groupsContainerSelector} > [data-group-id]`)];
-        // If a project was dropped on the Create New Group element...
-        let tempGroupElement = document.querySelector('#tempGroup');
-        if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
-            // ... Handle it as a new group
-            groupElements.push(tempGroupElement);
+        // If showAddGroupButtonTile setting is true & a project was dropped on the Create New Group element...
+        if (infos.config.showAddGroupButtonTile) {
+            let tempGroupElement = document.querySelector('#tempGroup');
+            if (tempGroupElement && tempGroupElement.querySelector("[data-id]")) {
+                // ... Handle it as a new group
+                groupElements.push(tempGroupElement);
+            }
         }
 
         let groupOrders = [];


### PR DESCRIPTION
Kept `tempGroupElement` integrity, adding the `showAddGroupButtonTile` setting to control the display of the entire div & made the drag & drop responsive to the setting.

Refactored `showAddButton` to `showAddProjectButton` to better reflect the meaning.

Replaces #73 => PR to develop branch instead of master
Fixes #72