### PR TITLE
Fix customCss does not working issue

### DIFF
--- a/src/webview/webviewContent.ts
+++ b/src/webview/webviewContent.ts
@@ -74,7 +74,7 @@ export function getDashboardContent(
         />
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="stylesheet" type="text/css" href="${stylesPath}">
-        <style>${colorDefaults()}
+        <style>${colorDefaults()}</style>
         <style>
             /* Custom CSS from configuration */
             ${customCss}


### PR DESCRIPTION
The closing bracket was missing from the previous tag. Otherwise it's only working if you write the customCss like this: customCss = '</style><style>body {...}'